### PR TITLE
Add img tag support for older browsers and search engines

### DIFF
--- a/lib/media_manager_plus.php
+++ b/lib/media_manager_plus.php
@@ -4,7 +4,8 @@
 			$sql = rex_sql::factory();
 			$breakpoints = $sql->getArray("SELECT name, mediaquery FROM `".rex::getTablePrefix()."media_manager_plus_breakpoints` ORDER BY `name` ASC");
 			unset($sql);
-			
+
+			array_push($breakpoints, ['name'=>'fallback', 'mediaquery'=>'']);
 			$breakpointsCombined = array_combine(array_column($breakpoints, 'name'), array_column($breakpoints, 'mediaquery'));
 			
 			return $breakpointsCombined;

--- a/lib/media_manager_plus_frontend.php
+++ b/lib/media_manager_plus_frontend.php
@@ -93,11 +93,46 @@
 			$imgtag = '';
 			
 			if ($lazyload) $classes[] = 'lazyload';
+
 			$classes = rex_extension::registerPoint(new rex_extension_point('MMP_IMG_CLASS', $classes, ['mediatype' => $mediatype, 'filename' => $filename, 'filenamesByBreakpoint' => $filenamesByBreakpoint, 'lazyload' => boolval($lazyload)]));
+
 			$imgtag = rex_extension::registerPoint(new rex_extension_point('MMP_IMGTAG', $imgtag, ['mediatype' => $mediatype, 'filename' => $filename, 'filenamesByBreakpoint' => $filenamesByBreakpoint, 'lazyload' => boolval($lazyload)]));
-			
+
 			if ($imgtag == '') {
-				$imgtag = '	<img '.(sizeof($classes) > 0 ? 'class="'.implode(' ', $classes).'"' : '').' src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" alt="'.addslashes(rex_media::get($filename)->getTitle()).'">'.PHP_EOL;
+
+				$imgSrcPath = 'index.php?rex_media_type='.$mediatype.'-fallback@1x'.'&rex_media_file='.$filename;
+
+				$imgSrcSetPath = '';
+				foreach (self::getResolutions() as $resolution => $factor) {
+						if ($resolution == 'lazy') continue;
+						$imgSrcSetPath .= 'index.php?rex_media_type='.$mediatype.'-fallback@'.$resolution.''.'&rex_media_file='.$filename.' '.$resolution.',';
+				}
+				$imgSrcSetPath = substr($imgSrcSetPath, 0, -1);
+
+				if (!$lazyload) {
+
+					$imgSrc = $imgSrcPath;
+					$imgSrcSet = $imgSrcSetPath;
+
+					$imgLazySrc = '';
+					$imgLazySrcSet = '';
+
+				} else {
+					$imgSrcLazy = 'index.php?rex_media_type='.$mediatype.'-fallback@lazy'.'&rex_media_file='.$filename;
+
+					$imgSrc = $imgSrcLazy;
+					$imgLazySrc = ' data-src="'.$imgSrcPath.'"';
+
+					$imgSrcSet = $imgSrcLazy;
+
+					$imgLazySrcSet .= ' data-srcset="';
+					$imgLazySrcSet .= $imgSrcSetPath;
+					$imgLazySrcSet .= '"'.PHP_EOL;
+
+				}
+
+				$imgtag = '	<img '.(sizeof($classes) > 0 ? 'class="'.implode(' ', $classes).'"' : '').' src="'.$imgSrc.'"'.$imgLazySrc.'srcset="'.$imgSrcSet.'"'.$imgLazySrcSet.' alt="'.addslashes(rex_media::get($filename)->getTitle()).'">'.PHP_EOL;
+
 			}
 			
 			$str .= $imgtag;


### PR DESCRIPTION
Older browsers can´t use the picture tag and does not show any images. Also search engines can´t index images, because actually it shows only a 1x1 px gif in base64 format.